### PR TITLE
Slurm jobs allocate the max memory available on the node

### DIFF
--- a/sbench/commands.py
+++ b/sbench/commands.py
@@ -16,7 +16,7 @@ mpi_stacks = [
     ('gcc/6.4.0', 'mvapich2'),
     ('gcc/6.4.0', 'openmpi'),
     ('gcc/7.3.0', 'mvapich2'),
-    ('gcc/6.4.0', 'openmpi'),
+    ('gcc/7.3.0', 'openmpi'),
     ('intel/18.0.2', 'intel-mpi')
 ]
 

--- a/sbench/templates/slurm_template.sh
+++ b/sbench/templates/slurm_template.sh
@@ -3,6 +3,7 @@
 #SBATCH --account=scitas-ge
 #SBATCH --job-name {{ name }}
 #SBATCH --constraint={{ target }}
+#SBATCH --mem=MaxMemPerNode
 #SBATCH --nodes={{ nnodes }}
 {% if ntasks %}
 #SBATCH --ntasks={{ ntasks }}
@@ -20,7 +21,6 @@ date -R >> {{ test_directory }}/run.${SLURM_JOB_ID}.start
 env >> {{ test_directory }}/run.${SLURM_JOB_ID}.env
 
 # Execute the benchmark
-slmodules -r future
 module load {{ compiler }} {{ mpi }}
 
 {% include test_template %}


### PR DESCRIPTION
Also fixes two other bugs:
  - Wrong compiler entry in the mpi stack.
  - Batch jobs don't load anymore the "future" environment.

See SL-602 for details.