### PR TITLE
Added `--exclusive` to the requests we pass to Slurm

### DIFF
--- a/sbench/templates/slurm_template.sh
+++ b/sbench/templates/slurm_template.sh
@@ -5,6 +5,7 @@
 #SBATCH --job-name {{ name }}
 #SBATCH --constraint={{ target }}
 #SBATCH --mem=MaxMemPerNode
+#SBATCH --exclusive
 #SBATCH --nodes={{ nnodes }}
 {% if ntasks %}
 #SBATCH --ntasks={{ ntasks }}


### PR DESCRIPTION
The option `--exclusive` ensures that on Deneb we won't land on a node of the "serial" partition and that on Fidis every job will run on an exclusive node (by default nodes are exclusive per user and not per job).

